### PR TITLE
fix: remove deprecated torchaudio backend setting

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,14 +4,6 @@ import torch.nn as nn
 import torchaudio
 import torchaudio.transforms as T
 
-# Configure torchaudio backend to prevent deprecation warnings
-try:
-    # Try setting backend if the method exists (older versions)
-    if hasattr(torchaudio, 'set_audio_backend'):
-        torchaudio.set_audio_backend("soundfile")
-except Exception:
-    # For newer versions, backend is handled automatically
-    pass
 import numpy as np
 import matplotlib.pyplot as plt
 from streamlit_webrtc import webrtc_streamer, AudioProcessorBase, WebRtcMode


### PR DESCRIPTION
Fixes #11

## Summary
- Remove deprecated torchaudio.set_audio_backend call that was causing warnings
- Function is now a no-op with dispatcher enabled and can be safely removed
- Should resolve segmentation fault caused by deprecated API usage

## Test plan
- [ ] Test model upload and loading
- [ ] Test audio recording functionality
- [ ] Verify no deprecation warnings appear
- [ ] Confirm no segmentation fault occurs

🤖 Generated with [Claude Code](https://claude.ai/code)