### PR TITLE
fix: resolve AudioProcessor type checking issue in factory validation

### DIFF
--- a/app.py
+++ b/app.py
@@ -1535,10 +1535,16 @@ def main():
                     else:
                         raise RuntimeError("audio_processor not initialized and model unavailable for recreation")
                 
-                # Step 3: Validate AudioProcessor type and methods
-                if not isinstance(st.session_state.audio_processor, AudioProcessor):
-                    debug_log(f"Factory: audio_processor has wrong type: {type(st.session_state.audio_processor)}", "error")
-                    raise RuntimeError(f"audio_processor has wrong type, expected AudioProcessor, got {type(st.session_state.audio_processor)}")
+                # Step 3: Validate AudioProcessor type and methods (using flexible type checking)
+                audio_processor_type = type(st.session_state.audio_processor)
+                audio_processor_name = audio_processor_type.__name__
+                
+                # Check if the object is an AudioProcessor by class name (handles module reloading issues)
+                if audio_processor_name != 'AudioProcessor':
+                    debug_log(f"Factory: audio_processor has wrong class name: {audio_processor_name}", "error")
+                    raise RuntimeError(f"audio_processor has wrong class name, expected 'AudioProcessor', got '{audio_processor_name}'")
+                
+                debug_log(f"Factory: AudioProcessor type validation passed: {audio_processor_type}")
                 
                 # Step 4: Check if it has the required recv_audio method
                 if not hasattr(st.session_state.audio_processor, 'recv_audio'):


### PR DESCRIPTION
Resolves #24

This PR fixes the "audio_processor has wrong type, expected AudioProcessor, got <class '__main__.AudioProcessor'>" error that occurs during WebRTC initialization.

## Changes
- Replace isinstance() check with class name validation to handle module reloading
- Fix type checking logic that was incorrectly rejecting valid AudioProcessor instances
- Add detailed debug logging for type validation process
- Improve robustness against Streamlit module reloading issues

## Root Cause
The error was caused by Streamlit's module reloading behavior where the same AudioProcessor class was being seen as different types during isinstance() checks. The solution uses class name comparison instead of strict type identity checking.

## Testing
Tested the fix to ensure proper AudioProcessor validation without false type checking errors.

Generated with [Claude Code](https://claude.ai/code)